### PR TITLE
poprawienie obsługi DEFAULT '...' i DEFAULT NULL

### DIFF
--- a/MySQLDump.php
+++ b/MySQLDump.php
@@ -144,10 +144,10 @@ class MySQLDump {
 			return false;
 		while ( $record = mysql_fetch_assoc($records) ) {
 			$structure .= '`'.$record['Field'].'` '.$record['Type'];
-			if ( !empty($record['Default']) )
-				$structure .= ' DEFAULT \''.$record['Default'].'\'';
 			if ( @strcmp($record['Null'],'YES') != 0 )
 				$structure .= ' NOT NULL';
+			if ( !empty($record['Default']) || @strcmp($record['Null'],'YES') == 0) 
+				$structure .= ' DEFAULT '.(is_null($record['Default']) ? 'NULL' : "'{$record['Default']}'");
 			if ( !empty($record['Extra']) )
 				$structure .= ' '.$record['Extra'];
 			$structure .= ",\n";


### PR DESCRIPTION
# ORYGINALNY PHPMYADMIN DUMP

CREATE TABLE IF NOT EXISTS `news` (
    `newsId` int(11) NOT NULL AUTO_INCREMENT,
    `newsName` varchar(100) NOT NULL,
    `date` date **NOT NULL DEFAULT '2014-01-01',**
    `langName` varchar(50) NOT NULL,
    `html` text NOT NULL,
    `published` varchar(1) NOT NULL,
    `news_categoryId` int(11) **DEFAULT NULL,**
        PRIMARY KEY (`newsId`),
        KEY `news_categoryId` (`news_categoryId`)
) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=10 ;
# FK_DUMP

CREATE TABLE `news` (
    `newsId` int(11) NOT NULL auto_increment,
    `newsName` varchar(100) NOT NULL,
    `date` date **NOT NULL,**
    `langName` varchar(50) NOT NULL,
    `html` text NOT NULL,
    `published` varchar(1) NOT NULL,
    `news_categoryId` int(11) **,**
        PRIMARY KEY  (`newsId`),
        KEY `news_categoryId` (`news_categoryId`)
) ENGINE=InnoDB AUTO_INCREMENT=10;
# POPRAWIONE

CREATE TABLE `news` (
    `newsId` int(11) NOT NULL auto_increment,
    `newsName` varchar(100) NOT NULL,
    `date` date **NOT NULL DEFAULT '2014-01-01',**
    `langName` varchar(50) NOT NULL,
    `html` text NOT NULL,
    `published` varchar(1) NOT NULL,
    `news_categoryId` int(11) **DEFAULT NULL,**
        PRIMARY KEY  (`newsId`),
        KEY `news_categoryId` (`news_categoryId`)
) ENGINE=InnoDB AUTO_INCREMENT=10;
