### PR TITLE
Poprawka zapisu FK w pliku skompresowanym

### DIFF
--- a/FKMySQLDump.php
+++ b/FKMySQLDump.php
@@ -56,16 +56,16 @@ class FKMySQLDump extends MySQLDump{
      * @return bool
      */
     function doFKDump() {
-        parent::doDump();
+        parent::doDumpWithoutClosing();
         $this->getForeignKeys();
-        $sql_file = file_get_contents($this->_fileName);
-        $sql_file .= "-- ------------\n";
+        $sql_file  = "-- ------------\n";
         $sql_file .= "-- FOREIGN KEYS\n";
         $sql_file .= "-- ------------\n";
         $sql_file .= "SET FOREIGN_KEY_CHECKS = 0;\n\n";
         $sql_file .= $this->getForeignKeysRules();
         $sql_file .= "SET FOREIGN_KEY_CHECKS = 1;\n\n";
-        file_put_contents($this->_fileName,$sql_file);
+        $this->saveToFile($this->file, $sql_file);
+		$this->closeFile($this->file);
 		return true;
     }
     

--- a/MySQLDump.php
+++ b/MySQLDump.php
@@ -273,12 +273,19 @@ class MySQLDump {
 	* Writes to file the selected database dump
 	*/
 	function doDump() {
+		$this->doDumpWithoutClosing();
+		$this->closeFile($this->file);
+		return true;
+	}
+	
+	/**	
+	* Writes to file the selected database dump
+	*/
+	protected function doDumpWithoutClosing() {
 		$this->saveToFile($this->file,"SET FOREIGN_KEY_CHECKS = 0;\n\n");
 		$this->getDatabaseStructure();
 		$this->getDatabaseData($this->hexValue);
 		$this->saveToFile($this->file,"SET FOREIGN_KEY_CHECKS = 1;\n\n");
-		$this->closeFile($this->file);
-		return true;
 	}
 	
 	/**


### PR DESCRIPTION
z opcją compress = true nie dopisywał kluczy obcych
